### PR TITLE
Fix no document

### DIFF
--- a/papis_zotero/server.py
+++ b/papis_zotero/server.py
@@ -248,6 +248,8 @@ class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
 
         self.send_response(201)  # Created
         self.set_zotero_headers()
+        # return the JSON data back
+        self.wfile.write(rawinput)
 
     def snapshot(self):
         logger.warning("Snapshot not implemented")

--- a/papis_zotero/server.py
+++ b/papis_zotero/server.py
@@ -239,12 +239,11 @@ class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
 
             papis_item = zotero_data_to_papis_data(item)
             if len(files) == 0:
-                logger.error('Not adding any attachments...')
+                logger.warning('Not adding any attachments...')
             logger.info("Adding paper")
             papis.commands.add.run(
                 files,
-                data=papis_item,
-                no_document=len(files) == 0
+                data=papis_item
             )
 
         self.send_response(201)  # Created


### PR DESCRIPTION
This should provide a basic fix for the issue #2. The Zotero connector still has some weird behaviour, it opens login window for [zotero.org](https://zotero.org) and then produces an error message, but Papis saves the metadata correctly, so it is not a big issue.