### PR TITLE
sql: convert fields to be more in line with main papis

### DIFF
--- a/papis_zotero/sql.py
+++ b/papis_zotero/sql.py
@@ -39,10 +39,12 @@ ZOTERO_TO_PAPIS_FIELD_MAP = {
     "DOI": "doi",
     "itemType": "type",
     "ISBN": "isbn",
+    "ISSN": "issn",
 }
 
-# seperator between multiple tags
-ZOTERO_TAG_DELIMITER = ","
+# separator between multiple tags
+# FIXME: this should be handled by papis
+ZOTERO_TAG_DELIMITER = " "
 
 
 def get_fields(connection: sqlite3.Connection, item_id: str) -> Dict[str, str]:
@@ -167,7 +169,8 @@ def get_tags(connection: sqlite3.Connection, item_id: str) -> Dict[str, str]:
     cursor = connection.cursor()
     cursor.execute(item_tag_query, (item_id,))
 
-    return {"tags": ZOTERO_TAG_DELIMITER.join(str(row[0]) for row in cursor)}
+    tags = ZOTERO_TAG_DELIMITER.join(str(row[0]) for row in cursor)
+    return {"tags": tags} if tags else {}
 
 
 def get_collections(connection: sqlite3.Connection,

--- a/papis_zotero/sql.py
+++ b/papis_zotero/sql.py
@@ -37,9 +37,6 @@ ZOTERO_INCLUDED_MIMETYPE_MAP = {
     "application/zip": "zip",
 }
 
-# dictionary translating from Zotero to papis type names
-ZOTERO_TO_PAPIS_TYPE_MAP = {"journalArticle": "article"}
-
 # dictionary translating from zotero to papis field names
 ZOTERO_TO_PAPIS_FIELD_MAP = {
     "abstractNote": "abstract",
@@ -298,7 +295,7 @@ def add_from_sql(input_path: str, output_path: str) -> None:
         date_added = (
             datetime.strptime(date_added, "%Y-%m-%d %H:%M:%S")
             .strftime(papis.strings.time_format))
-        item_type = ZOTERO_TO_PAPIS_TYPE_MAP.get(item_type, item_type)
+        item_type = papis.bibtex.bibtex_type_converter.get(item_type, item_type)
         logger.info("[%4d / %4d] Exporting item '%s'.", i, items_count, item_key)
 
         # get Zotero metadata

--- a/papis_zotero/sql.py
+++ b/papis_zotero/sql.py
@@ -188,7 +188,8 @@ def get_collections(connection: sqlite3.Connection,
     cursor = connection.cursor()
     cursor.execute(item_collection_query, (item_id,))
 
-    return {"project": [name for name, in cursor]}
+    project = [name for name, in cursor]
+    return {"project": project} if project else {}
 
 
 def add_from_sql(input_path: str, output_path: str) -> None:

--- a/tests/resources/sql_out.yaml
+++ b/tests/resources/sql_out.yaml
@@ -1,0 +1,23 @@
+author: Svärd, Magnus and Nordström, Jan
+author_list:
+- family: Svärd
+  given: Magnus
+- family: Nordström
+  given: Jan
+doi: 10.1016/j.jcp.2014.02.031
+files:
+- WN7WJBGS.pdf
+issn: 00219991
+journal: Journal of Computational Physics
+journalAbbreviation: Journal of Computational Physics
+language: en
+libraryCatalog: DOI.org (Crossref)
+month: 7
+pages: 17-38
+ref: ReviewOfSummaSvard2014
+time-added: 2023-02-26-09:05:00
+title: Review of summation-by-parts schemes for initial–boundary-value problems
+type: article
+url: https://linkinghub.elsevier.com/retrieve/pii/S002199911400151X
+volume: '268'
+year: 2014

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -5,14 +5,10 @@ import pytest
 import papis.document
 import papis_zotero.sql
 
-from .testlib import TemporaryLibrary
-
-
 @pytest.mark.library_setup(populate=False)
 def test_simple(tmp_library: TemporaryLibrary) -> None:
     sqlpath = os.path.join(os.path.dirname(__file__), "data", "Zotero")
     papis_zotero.sql.add_from_sql(sqlpath, tmp_library.libdir)
-
     folders = os.listdir(tmp_library.libdir)
     assert len(folders) == 5
     assert len(glob.glob(tmp_library.libdir + "/**/*.pdf")) == 4

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -18,7 +18,7 @@ def test_simple(tmp_library: TemporaryLibrary) -> None:
     assert len(folders) == 5
     assert len(glob.glob(tmp_library.libdir + "/**/*.pdf")) == 4
 
-    doc = papis.document.from_folder(os.path.join(tmp_library.libdir, folders[0]))
+    doc = papis.document.from_folder(os.path.join(tmp_library.libdir, "IH8J2JJP"))
 
     info_name = os.path.join(os.path.dirname(__file__), "resources", "sql_out.yaml")
     with open(info_name, encoding="utf-8") as fd:

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -1,9 +1,14 @@
 import os
 import glob
+import yaml
 import pytest
 
+import papis.yaml
 import papis.document
 import papis_zotero.sql
+
+from .testlib import TemporaryLibrary
+
 
 @pytest.mark.library_setup(populate=False)
 def test_simple(tmp_library: TemporaryLibrary) -> None:
@@ -14,7 +19,13 @@ def test_simple(tmp_library: TemporaryLibrary) -> None:
     assert len(glob.glob(tmp_library.libdir + "/**/*.pdf")) == 4
 
     doc = papis.document.from_folder(os.path.join(tmp_library.libdir, folders[0]))
-    assert doc["ref"] in folders
+
+    info_name = os.path.join(os.path.dirname(__file__), "resources", "sql_out.yaml")
+    with open(info_name, encoding="utf-8") as fd:
+        data = yaml.load(fd, Loader=papis.yaml.Loader)  # type: ignore[attr-defined]
+        expected_doc = papis.document.from_data(data)
+
+    assert expected_doc["ref"] == doc["ref"]
 
     # FIXME: currently fails on windows
     # assert doc.get_files()


### PR DESCRIPTION
This does a pretty big update to `papis_zotero.sql` to clean up and update all the fields that get imported. The main motivation was to make them more in line with what `papis` generates with the builtin importers.

The commits should be self-contained and self-explanatory.