### PR TITLE
import: use libdir for outfolder by default

### DIFF
--- a/papis_zotero/__init__.py
+++ b/papis_zotero/__init__.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 import click
 
+import papis.config
 import papis.logging
 import papis_zotero.server
 
@@ -69,17 +70,20 @@ def serve(address: str, port: int) -> None:
 @click.option("-o",
               "--outfolder",
               help="Folder to save the imported library",
-              type=str,
-              required=True)
+              default=None,
+              type=str)
 @click.option("--link",
               help="Wether to link the pdf files or copy them",
               is_flag=True,
               default=False)
 def do_importer(from_bibtex: Optional[str], from_sql: Optional[str],
-                outfolder: str, link: bool) -> None:
+                outfolder: Optional[str], link: bool) -> None:
     """Import zotero libraries into papis libraries."""
     import papis_zotero.bibtex
     import papis_zotero.sql
+
+    if outfolder is None:
+        outfolder = papis.config.get_lib_dirs()[0]
 
     if not os.path.exists(outfolder):
         os.makedirs(outfolder)

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -13,7 +13,7 @@ from .testlib import TemporaryLibrary
 @pytest.mark.library_setup(populate=False)
 def test_simple(tmp_library: TemporaryLibrary) -> None:
     sqlpath = os.path.join(os.path.dirname(__file__), "data", "Zotero")
-    papis_zotero.sql.add_from_sql(sqlpath, tmp_library.libdir)
+    papis_zotero.sql.add_from_sql(sqlpath)
     folders = os.listdir(tmp_library.libdir)
     assert len(folders) == 5
     assert len(glob.glob(tmp_library.libdir + "/**/*.pdf")) == 4


### PR DESCRIPTION
This changes the default for `papis zotero import --outfolder` to use `papis.config.get_lib_dirs()[0]` when no folder is given.

Fixes #6