### PR TITLE
serve: update conversions and cleanup

### DIFF
--- a/papis_zotero/server.py
+++ b/papis_zotero/server.py
@@ -5,22 +5,15 @@ into papis.
 
 """
 
-import http.server
 import json
-import re
-import tempfile
-import urllib.request
-import urllib.error
-
-from typing import Any, Dict
+import http.server
+from typing import Any, Dict, List
 
 import papis.api
-import papis.config
 import papis.crossref
 import papis.document
+import papis.commands.add
 import papis.logging
-
-import papis_zotero.utils
 
 logger = papis.logging.get_logger(__name__)
 
@@ -28,44 +21,105 @@ ZOTERO_CONNECTOR_API_VERSION = 2
 ZOTERO_VERSION = "5.0.25"
 ZOTERO_PORT = 23119
 
+_k = papis.document.KeyConversionPair
+
+ZOTERO_IGNORED_FIELDS = frozenset({
+    "id", "attachments", "extra", "shortTitle", "accessDate",
+})
+
+ZOTERO_TO_PAPIS_CONVERSIONS = [
+    _k("creators", [{
+        "key": "author_list",
+        "action": lambda a: zotero_authors(a)
+        }]),
+    _k("tags", [{
+        "key": "tags",
+        "action": lambda t: "; ".join(tag["tag"] for tag in t)
+        }]),
+    _k("date", [
+        {"key": "year", "action": lambda d: int(d.split("-")[0])},
+        {"key": "month", "action": lambda d: int(d.split("-")[1])},
+        ]),
+    _k("archiveID", [
+        {"key": "eprint", "action": lambda a: a.split(":")[-1]}
+        ]),
+    _k("type", [
+        {"key": "type", "action": papis.bibtex.bibtex_type_converter.get}
+        ]),
+]
+
+
+def zotero_authors(creators: List[Dict[str, str]]) -> List[Dict[str, str]]:
+    authors = []
+    for creator in creators:
+        if creator["creatorType"] != "author":
+            continue
+
+        authors.append({
+            "given": creator["firstName"],
+            "family": creator["lastName"],
+        })
+
+    return authors
+
 
 def zotero_data_to_papis_data(item: Dict[str, Any]) -> Dict[str, Any]:
-    from papis_zotero.sql import ZOTERO_TO_PAPIS_FIELD_MAP
-    data = {}
-
-    # NOTE: these are handled elsewhere
     item.pop("id", None)
     item.pop("attachments", None)
 
-    # translate known zotero keys
-    for key in ZOTERO_TO_PAPIS_FIELD_MAP:
-        value = item.pop(key, None)
-        if value is not None:
-            data[ZOTERO_TO_PAPIS_FIELD_MAP[key]] = value
+    from papis_zotero.sql import ZOTERO_TO_PAPIS_FIELD_MAP
+    for foreign_key, key in ZOTERO_TO_PAPIS_FIELD_MAP.items():
+        if foreign_key in item:
+            item[key] = item.pop(foreign_key)
 
-    # check zotero tags
-    tags = item.pop("tags", None)
-    if isinstance(tags, list):
-        data["tags"] = " ".join(tags)
-
-    data.update(item)
+    item = papis.document.keyconversion_to_data(ZOTERO_TO_PAPIS_CONVERSIONS,
+                                                item,
+                                                keep_unknown_keys=True)
+    for key in ZOTERO_IGNORED_FIELDS:
+        if key in item:
+            del item[key]
 
     # try to get information from Crossref as well
-    doi = data.get("doi")
-    if doi is not None:
-        crossref_data = papis.crossref.doi_to_data(str(doi))
-        crossref_data.pop("title", None)
+    if "doi" in item:
+        try:
+            crossref_data = papis.crossref.doi_to_data(item["doi"])
+            crossref_data.pop("title", None)
+            logger.info("Updating document with data from Crossref.")
+        except ValueError:
+            crossref_data = {}
 
-        logger.info("Updating document with data from Crossref.")
-        data.update(crossref_data)
+        item.update(crossref_data)
 
-    return data
+    logger.info("Document metadata: %s", item)
+    return item
+
+
+def download_zotero_attachments(attachments: List[Dict[str, str]]) -> List[str]:
+    from papis.downloaders import download_document
+    from papis_zotero.sql import ZOTERO_INCLUDED_MIMETYPE_MAP
+    files = []
+
+    for attachment in attachments:
+        logger.info("Checking attachment: %s", attachment)
+
+        mime = str(attachment.get("mimeType"))
+        if mime not in ZOTERO_INCLUDED_MIMETYPE_MAP:
+            continue
+
+        url = attachment["url"]
+        extension = ZOTERO_INCLUDED_MIMETYPE_MAP[mime]
+        logger.info("Downloading file (%s): '%s'.", mime, url)
+
+        filename = download_document(url, expected_document_extension=extension)
+        if filename is not None:
+            files.append(filename)
+
+    return files
 
 
 class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
-
     def log_message(self, fmt: str, *args: Any) -> None:
-        logger.info(fmt, args)
+        logger.info(fmt, *args)
 
     def set_zotero_headers(self) -> None:
         self.send_header("X-Zotero-Version", ZOTERO_VERSION)
@@ -77,114 +131,89 @@ class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
         length = int(self.headers["content-length"])
         return self.rfile.read(length)
 
-    def pong(self, POST: bool = True) -> None:  # noqa: N803
-        # Pong must respond to ping on both GET and POST
-        # It must accepts application/json and text/plain
-        if not POST:  # GET
-            logger.debug("Received a GET request.")
-            self.send_response(200)
-            self.send_header("Content-Type", "text/html")
-            self.set_zotero_headers()
-            response = """\
-            <!DOCTYPE html>
-            <html>
-                <head>
-                    <title>Zotero Connector Server is Available</title>
-                </head>
-                <body>
-                    Zotero Connector Server is Available
-                </body>
-            </html>
-            """
-        else:  # POST
-            logger.debug("Received a POST request.")
-            self.send_response(200)
-            self.send_header("Content-Type", "application/json")
-            self.set_zotero_headers()
-            response = json.dumps({"prefs": {"automaticSnapshots": True}})
+    def do_GET(self) -> None:  # noqa: N802
+        logger.info("Received GET request at '%s'", self.path)
+        if self.path == "/connector/ping":
+            self.handle_get_ping()
 
-        self.wfile.write(bytes(response, "utf8"))
+    def handle_get_ping(self) -> None:
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html")
+        self.set_zotero_headers()
+        response = """\
+        <!DOCTYPE html>
+        <html>
+            <head>
+                <title>Zotero Connector Server is Available</title>
+            </head>
+            <body>
+                Zotero Connector Server is Available
+            </body>
+        </html>
+        """
 
-    def papis_collection(self) -> None:
+        self.wfile.write(response.encode("utf-8"))
+
+    def do_POST(self) -> None:  # noqa: N802
+        logger.info("Received POST request at '%s'", self.path)
+        if self.path == "/connector/ping":
+            self.handle_post_ping()
+        elif self.path == "/connector/getSelectedCollection":
+            self.handle_post_collection()
+        elif self.path == "/connector/saveSnapshot":
+            self.handle_post_snapshot()
+        elif self.path == "/connector/saveItems":
+            self.handle_post_add()
+
+    def handle_post_ping(self) -> None:
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.set_zotero_headers()
+        response = json.dumps({"prefs": {"automaticSnapshots": True}})
+
+        self.wfile.write(response.encode("utf-8"))
+
+    def handle_post_collection(self) -> None:
         self.send_response(200)
         self.send_header("Content-Type", "application/json")
         self.set_zotero_headers()
         papis_library = papis.api.get_lib_name()
+
         response = json.dumps({
             "libraryID": 1,
             "libraryName": papis_library,
-            # I'm not aware of a read-only papis mode
             "libraryEditable": True,
-            # collection-level parameters
             "editable": True,
-            # collection-level
             "id": None,
-            # collection if collection, else library
             "name": papis_library
         })
-        self.wfile.write(bytes(response, "utf8"))
 
-    def add(self) -> None:
+        self.wfile.write(response.encode("utf-8"))
+
+    def handle_post_add(self) -> None:
         logger.info("Adding paper from the Zotero Connector.")
         rawinput = self.read_input()
-        data = json.loads(rawinput.decode("utf8"))
+        data = json.loads(rawinput.decode("utf-8"))
 
+        logger.info("Response: %s", data)
         for item in data["items"]:
-            files = []
-            if item.get("attachments") and len(item.get("attachments")) > 0:
-                for attachment in item.get("attachments"):
-                    mime = str(attachment.get("mimeType"))
-                    logger.info("Checking attachment (mime %s).", mime)
-                    if re.match(r".*pdf.*", mime):
-                        url = attachment.get("url")
-                        logger.info("Downloading PDF: '%s'.", url)
-                        try:
-                            pdfbuffer = urllib.request.urlopen(url).read()
-                        except urllib.error.HTTPError:
-                            logger.error(
-                                "Error downloading PDF. You probably do not"
-                                "have the rights to access the journal.")
-                            continue
-
-                        pdfpath = tempfile.mktemp(suffix=".pdf")
-                        logger.info("Saving PDF: '%s'", pdfpath)
-
-                        with open(pdfpath, "wb+") as fd:
-                            fd.write(pdfbuffer)
-
-                        if papis_zotero.utils.is_pdf(pdfpath):
-                            files.append(pdfpath)
-                        else:
-                            logger.error(
-                                "File retrieved does not appear to be a PDF. "
-                                "Skipping!")
+            attachments = item.get("attachments", [])
+            if attachments:
+                files = download_zotero_attachments(attachments)
             else:
                 logger.info("Document has no attachments.")
+                files = []
 
             papis_item = zotero_data_to_papis_data(item)
             logger.info("Adding paper to papis.")
             papis.commands.add.run(files, data=papis_item)
 
-        self.send_response(201)  # Created
-        self.set_zotero_headers()
-        # return the JSON data back
-        self.wfile.write(rawinput)
-
-    def snapshot(self) -> None:
-        logger.error("Snapshot not implemented!")
         self.send_response(201)
         self.set_zotero_headers()
 
-    def do_POST(self) -> None:  # noqa: N802
-        if self.path == "/connector/ping":
-            self.pong()
-        elif self.path == "/connector/getSelectedCollection":
-            self.papis_collection()
-        elif self.path == "/connector/saveSnapshot":
-            self.snapshot()
-        elif self.path == "/connector/saveItems":
-            self.add()
+        self.wfile.write(rawinput)
 
-    def do_GET(self) -> None:  # noqa: N802
-        if self.path == "/connector/ping":
-            self.pong(POST=False)
+    def handle_post_snapshot(self) -> None:
+        logger.error("Snapshot not implemented!")
+        self.send_response(201)
+        self.set_zotero_headers()

--- a/papis_zotero/server.py
+++ b/papis_zotero/server.py
@@ -43,7 +43,7 @@ ZOTERO_TO_PAPIS_CONVERSIONS = [
         {"key": "eprint", "action": lambda a: a.split(":")[-1]}
         ]),
     _k("type", [
-        {"key": "type", "action": papis.bibtex.bibtex_type_converter.get}
+        {"key": "type", "action": papis_zotero.utils.ZOTERO_TO_PAPIS_TYPES.get}
         ]),
 ]
 
@@ -93,7 +93,6 @@ def zotero_data_to_papis_data(item: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def download_zotero_attachments(attachments: List[Dict[str, str]]) -> List[str]:
-    from papis.downloaders import download_document
     files = []
 
     for attachment in attachments:
@@ -107,7 +106,8 @@ def download_zotero_attachments(attachments: List[Dict[str, str]]) -> List[str]:
         extension = papis_zotero.utils.ZOTERO_SUPPORTED_MIMETYPES_TO_EXTENSION[mime]
         logger.info("Downloading file (%s): '%s'.", mime, url)
 
-        filename = download_document(url, expected_document_extension=extension)
+        filename = papis_zotero.utils.download_document(
+            url, expected_document_extension=extension)
         if filename is not None:
             files.append(filename)
 

--- a/papis_zotero/server.py
+++ b/papis_zotero/server.py
@@ -19,8 +19,9 @@ import papis_zotero.utils
 
 logger = papis.logging.get_logger(__name__)
 
+# NOTE: 5.0.75 was released in October 8, 2019 at the same time with Python 3.8
 ZOTERO_CONNECTOR_API_VERSION = 2
-ZOTERO_VERSION = "5.0.25"
+ZOTERO_VERSION = "5.0.75"
 ZOTERO_PORT = 23119
 
 _k = papis.document.KeyConversionPair

--- a/papis_zotero/sql.py
+++ b/papis_zotero/sql.py
@@ -6,6 +6,7 @@ import sqlite3
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
+import papis.yaml
 import papis.config
 import papis.bibtex
 import papis.strings
@@ -233,7 +234,6 @@ def add_from_sql(input_path: str, output_path: Optional[str] = None) -> None:
         existing
     """
     import yaml
-    import papis.yaml
 
     if output_path is None:
         output_path = papis.config.get_lib_dirs()[0]
@@ -270,7 +270,7 @@ def add_from_sql(input_path: str, output_path: Optional[str] = None) -> None:
         date_added = (
             datetime.strptime(date_added, "%Y-%m-%d %H:%M:%S")
             .strftime(papis.strings.time_format))
-        item_type = papis.bibtex.bibtex_type_converter.get(item_type, item_type)
+        item_type = papis_zotero.utils.ZOTERO_TO_PAPIS_TYPES.get(item_type, item_type)
 
         # get Zotero metadata
         fields = get_fields(connection, item_id)
@@ -295,8 +295,7 @@ def add_from_sql(input_path: str, output_path: Optional[str] = None) -> None:
                 ref = matches.group(1)
 
         if ref is None:
-            from papis.bibtex import create_reference
-            ref = create_reference(item)
+            ref = papis.bibtex.create_reference(item)
 
         item["ref"] = ref
         logger.info("[%4d/%-4d] Exporting item '%s' with ref '%s' to folder '%s'.",

--- a/papis_zotero/utils.py
+++ b/papis_zotero/utils.py
@@ -1,6 +1,43 @@
 import os
 import re
 
+# Zotero item types to be excluded when converting to papis
+ZOTERO_EXCLUDED_ITEM_TYPES = ("attachment", "note")
+
+# Zotero excluded fields
+ZOTERO_EXCLUDED_FIELDS = frozenset({
+    "accessDate",
+    "id",
+    "shortTitle",
+    "attachements",
+})
+
+# dictionary of Zotero attachments mimetypes to be included
+# NOTE: mapped onto their respective extension to be used in papis
+ZOTERO_SUPPORTED_MIMETYPES_TO_EXTENSION = {
+    "application/vnd.ms-htmlhelp": "chm",
+    "image/vnd.djvu": "djvu",
+    "application/msword": "doc",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
+    "docx",
+    "application/epub+zip": "epub",
+    "application/octet-stream": "fb2",
+    "application/x-mobipocket-ebook": "mobi",
+    "application/pdf": "pdf",
+    "text/rtf": "rtf",
+    "application/zip": "zip",
+}
+
+# dictionary translating from zotero to papis field names
+ZOTERO_TO_PAPIS_FIELDS = {
+    "abstractNote": "abstract",
+    "publicationTitle": "journal",
+    "DOI": "doi",
+    "itemType": "type",
+    "ISBN": "isbn",
+    "ISSN": "issn",
+}
+
 
 def is_pdf(filepath: str) -> bool:
     if not os.path.exists(filepath):

--- a/papis_zotero/utils.py
+++ b/papis_zotero/utils.py
@@ -1,5 +1,10 @@
-import os
-import re
+import tempfile
+from typing import Any, Dict, Optional
+
+import papis.utils
+import papis.logging
+
+logger = papis.logging.get_logger(__name__)
 
 # Zotero item types to be excluded when converting to papis
 ZOTERO_EXCLUDED_ITEM_TYPES = ("attachment", "note")
@@ -38,12 +43,95 @@ ZOTERO_TO_PAPIS_FIELDS = {
     "ISSN": "issn",
 }
 
+# TODO: This mapping is copied from 'papis.bibtex.bibtex_type_converter' with
+# no changes. It will be available in papis>0.13, so it should be deleted and
+# replaced when we can depend on a newer version
 
-def is_pdf(filepath: str) -> bool:
-    if not os.path.exists(filepath):
-        return False
+ZOTERO_TO_PAPIS_TYPES: Dict[str, str] = {
+    # Zotero
+    "annotation": "misc",
+    "attachment": "misc",
+    "audioRecording": "audio",
+    "bill": "legislation",
+    "blogPost": "online",
+    "bookSection": "inbook",
+    "case": "jurisdiction",
+    "computerProgram": "software",
+    "conferencePaper": "inproceedings",
+    "dictionaryEntry": "misc",
+    "document": "article",
+    "email": "online",
+    "encyclopediaArticle": "article",
+    "film": "video",
+    "forumPost": "online",
+    "hearing": "jurisdiction",
+    "instantMessage": "online",
+    "interview": "article",
+    "journalArticle": "article",
+    "magazineArticle": "article",
+    "manuscript": "unpublished",
+    "map": "misc",
+    "newspaperArticle": "article",
+    "note": "misc",
+    "podcast": "audio",
+    "preprint": "unpublished",
+    "presentation": "misc",
+    "radioBroadcast": "audio",
+    "statute": "jurisdiction",
+    "tvBroadcast": "video",
+    "videoRecording": "video",
+    "webpage": "online",
+    # Others
+    "journal": "article",
+    "monograph": "book",
+}
 
-    with open(filepath, "rb") as fd:
-        magic = fd.read(8)
 
-    return re.match(r"%PDF-.\..", magic.decode()) is not None
+# TODO: this function is copied from `papis.downloaders.__init__` with no
+# changes. It will be available in papis>0.13, so it should be deleted when
+# we can depend on a newer version
+
+def download_document(
+        url: str,
+        expected_document_extension: Optional[str] = None,
+        cookies: Optional[Dict[str, Any]] = None,
+        ) -> Optional[str]:
+    """Download a document from *url* and store it in a local file.
+
+    :param url: the URL of a remote file.
+    :param expected_document_extension: an expected file type. If *None*, then
+        an extension is guessed from the file contents, but this can also fail.
+    :returns: a path to a local file containing the data from *url*.
+    """
+    if cookies is None:
+        cookies = {}
+
+    try:
+        with papis.utils.get_session() as session:
+            response = session.get(url, cookies=cookies, allow_redirects=True)
+    except Exception as exc:
+        logger.error("Failed to fetch '%s'.", url, exc_info=exc)
+        return None
+
+    if not response.ok:
+        logger.error("Could not download document '%s'. (HTTP status: %s %d).",
+                     url, response.reason, response.status_code)
+        return None
+
+    ext = expected_document_extension
+    if ext is None:
+        from papis.filetype import guess_content_extension
+        ext = guess_content_extension(response.content)
+        if not ext:
+            logger.warning("Downloaded document does not have a "
+                           "recognizable (binary) mimetype: '%s'.",
+                           response.headers["Content-Type"])
+
+    ext = ".{}".format(ext) if ext else ""
+    with tempfile.NamedTemporaryFile(
+            mode="wb+",
+            suffix=ext,
+            delete=False) as f:
+        f.write(response.content)
+
+    return f.name


### PR DESCRIPTION
This updates the conversion of the items received from the Zotero connector to be more in line with the ones done by the SQL and BibTeX importers. For example, it now correctly converts Zotero `creators` to `authors` and `author_list` for papis.

It would be cool to add a test for this too. At the moment I just ran it manually with some arXiv paper to make sure everything still works.