### PR TITLE
general: mass ignore mypy issues from latest click release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
   schedule:
     # 17:00 on Friday (UTC)
     - cron: "00 17 * * 5"

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 .. image:: https://badge.fury.io/py/papis-zotero.svg
     :target: https://badge.fury.io/py/papis-zotero
 .. image:: https://github.com/papis/papis-zotero/workflows/CI/badge.svg
-   :target: https://github.com/papis/papis-zotero/actions?query=branch%3Amaster+workflow%3ACI
+   :target: https://github.com/papis/papis-zotero/actions?query=branch%3Amain+workflow%3ACI
 
 Zotero compatibility for papis
 ==============================

--- a/papis_zotero/__init__.py
+++ b/papis_zotero/__init__.py
@@ -11,13 +11,13 @@ import papis_zotero.server
 logger = papis.logging.get_logger(__name__)
 
 
-@click.group("zotero")
+@click.group("zotero")                  # type: ignore[arg-type]
 @click.help_option("-h", "--help")
 def main() -> None:
     """Zotero interface for papis."""
 
 
-@main.command("serve")
+@main.command("serve")                  # type: ignore[arg-type]
 @click.help_option("-h", "--help")
 @click.option("--port",
               help="Port to listen to",
@@ -50,7 +50,7 @@ def serve(address: str, port: int) -> None:
     httpd.serve_forever()
 
 
-@main.command("import")
+@main.command("import")                 # type: ignore[arg-type]
 @click.help_option("-h", "--help")
 @click.option(
     "-f",

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ strict = True
 show_column_numbers = True
 hide_error_codes = False
 pretty = True
+warn_unused_ignores = False
 
 [mypy-colorama.*]
 ignore_missing_imports = True


### PR DESCRIPTION
Latest `click` release 8.1.4 changed a lot of the typing annotations. They do not seem to be complete yet, so this just ignores all issues for the moment.