### PR TITLE
sql: use papis.yaml.data_to_yaml to dump the yaml

### DIFF
--- a/papis_zotero/sql.py
+++ b/papis_zotero/sql.py
@@ -236,7 +236,6 @@ def add_from_sql(input_path: str, output_path: Optional[str] = None) -> None:
     :param outpath: path where all items will be exported to created if not
         existing
     """
-    import yaml
 
     if output_path is None:
         output_path = papis.config.get_lib_dirs()[0]

--- a/papis_zotero/sql.py
+++ b/papis_zotero/sql.py
@@ -304,14 +304,7 @@ def add_from_sql(input_path: str, output_path: Optional[str] = None) -> None:
         logger.info("[%4d/%-4d] Exporting item '%s' with ref '%s' to folder '%s'.",
                     i, items_count, item_key, ref, path)
 
-        # write out the info file
-        # FIXME: should use papis.yaml.data_to_yaml, but blocked by
-        #   https://github.com/papis/papis/pull/571
-        with open(os.path.join(path, "info.yaml"), "w+", encoding="utf-8") as fd:
-            yaml.dump(item,
-                      stream=fd,
-                      allow_unicode=True,
-                      default_flow_style=False)
+        papis.yaml.data_to_yaml(yaml_path=os.path.join(path, "info.yaml"), data=item)
 
     logger.info("Finished exporting from '%s'.", input_path)
     logger.info("Exported files can be found at '%s'.", output_path)


### PR DESCRIPTION
I noticed this comment refers to a pull request, papis/papis#571, which was already merged.

This pull requests uses the indicated function to avoid manually dumping the yaml, which papis already does.