### PR TITLE
Use papis add for import

### DIFF
--- a/papis_zotero/__init__.py
+++ b/papis_zotero/__init__.py
@@ -94,7 +94,7 @@ def do_importer(from_bibtex: Optional[str], from_sql: Optional[str],
     elif from_sql is not None:
         import papis_zotero.sql
         try:
-            papis_zotero.sql.add_from_sql(from_sql, outfolder)
+            papis_zotero.sql.add_from_sql(from_sql, outfolder, link)
         except Exception as exc:
             logger.error("Failed to import from file: %s",
                          from_sql,

--- a/papis_zotero/sql.py
+++ b/papis_zotero/sql.py
@@ -276,20 +276,8 @@ def add_from_sql(input_path: str, out_folder: Optional[str] = None,
         item.update(get_tags(connection, item_id))
         item.update(get_collections(connection, item_id))
 
-        # create a reference
-        ref = None
-        extra = item.get("extra", None)
-        if extra:
-            matches = re.search(r".*Citation Key: (\w+)", extra)
-            if matches:
-                ref = matches.group(1)
-
-        if ref is None:
-            ref = papis.bibtex.create_reference(item)
-
-        item["ref"] = ref
-        logger.info("[%4d/%-4d] Exporting item '%s' with ref '%s' to library '%s'.",
-                    i, items_count, item_key, ref, out_folder)
+        logger.info("[%4d/%-4d] Exporting item '%s' to library '%s'.",
+                    i, items_count, item_key, out_folder)
 
         papis.commands.add.run(paths=files, data=item, link=link)
 

--- a/papis_zotero/sql.py
+++ b/papis_zotero/sql.py
@@ -141,8 +141,8 @@ def get_files(connection: sqlite3.Connection, item_id: str, item_key: str,
             file_name = match.group(1)
             files.append(os.path.join(input_path, "storage", key, file_name))
         else:
-            logger.error("Failed to export attachment with type (%s) and key '%s' from path '%s'",
-                         mime_type, key, path)
+            logger.error("Failed to export attachment %s (with type %s) from path '%s'",
+                         key, mime_type, path)
 
     return files
 
@@ -280,7 +280,9 @@ def add_from_sql(input_path: str, out_folder: Optional[str] = None,
         logger.info("[%4d/%-4d] Exporting item '%s' to library '%s'.",
                     i, items_count, item_key, out_folder)
 
-        papis.commands.add.run(paths=files, data=item, link=link)
+        papis.commands.add.run(paths=files, data=item, link=link,
+                               folder_name=papis.config.getstring("add-folder-name")
+                               )
 
     logger.info("Finished exporting from '%s'.", input_path)
     logger.info("Exported files can be found at '%s'.", out_folder)

--- a/papis_zotero/sql.py
+++ b/papis_zotero/sql.py
@@ -136,7 +136,8 @@ def get_files(connection: sqlite3.Connection, item_id: str, item_key: str,
 
     files = []
     for key, path in cursor:
-        if file_name := re.match("storage:(.*)", path).group(1):
+        if match := re.match("storage:(.*)", path):
+            file_name = match.group(1)
             files.append(os.path.join(input_path, "storage", key, file_name))
         else:
             logger.error("Failed to export attachment with key '%s' from path '%s'",

--- a/papis_zotero/sql.py
+++ b/papis_zotero/sql.py
@@ -115,7 +115,8 @@ def get_creators(connection: sqlite3.Connection,
 ZOTERO_QUERY_ITEM_ATTACHMENTS = """
 SELECT
     items.key,
-    itemAttachments.path
+    itemAttachments.path,
+    itemAttachments.contentType
 FROM
     itemAttachments,
     items
@@ -135,13 +136,13 @@ def get_files(connection: sqlite3.Connection, item_id: str, item_key: str,
         (item_id,) + tuple(papis_zotero.utils.ZOTERO_SUPPORTED_MIMETYPES_TO_EXTENSION))
 
     files = []
-    for key, path in cursor:
+    for key, path, mime_type in cursor:
         if match := re.match("storage:(.*)", path):
             file_name = match.group(1)
             files.append(os.path.join(input_path, "storage", key, file_name))
         else:
-            logger.error("Failed to export attachment with key '%s' from path '%s'",
-                         key, path)
+            logger.error("Failed to export attachment with type (%s) and key '%s' from path '%s'",
+                         mime_type, key, path)
 
     return files
 

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -19,14 +19,19 @@ def test_simple(tmp_library: TemporaryLibrary) -> None:
     assert len(folders) == 5
     assert len(glob.glob(tmp_library.libdir + "/**/*.pdf")) == 4
 
-    doc = papis.document.from_folder(os.path.join(tmp_library.libdir, "IH8J2JJP"))
+    doc = papis.document.from_folder(
+        os.path.join(
+            tmp_library.libdir,
+            "95e29aafd24e14274ab8a1bb7887e2b7-svard-magnus-and-no"
+            )
+        )
 
     info_name = os.path.join(os.path.dirname(__file__), "resources", "sql_out.yaml")
     with open(info_name, encoding="utf-8") as fd:
         data = yaml.load(fd, Loader=papis.yaml.Loader)  # type: ignore[attr-defined]
         expected_doc = papis.document.from_data(data)
 
-    assert expected_doc["ref"] == doc["ref"]
+    assert expected_doc["authors"] == doc["authors"]
 
     # FIXME: currently fails on windows
     # assert doc.get_files()

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -13,6 +13,7 @@ from .testlib import TemporaryLibrary
 @pytest.mark.library_setup(populate=False)
 def test_simple(tmp_library: TemporaryLibrary) -> None:
     sqlpath = os.path.join(os.path.dirname(__file__), "resources", "sql")
+    papis.config.set("add-folder-name", "{doc[author]}")
     papis_zotero.sql.add_from_sql(sqlpath)
 
     folders = os.listdir(tmp_library.libdir)
@@ -22,7 +23,7 @@ def test_simple(tmp_library: TemporaryLibrary) -> None:
     doc = papis.document.from_folder(
         os.path.join(
             tmp_library.libdir,
-            "95e29aafd24e14274ab8a1bb7887e2b7-svard-magnus-and-no"
+            "svard-magnus-and-nordstrom-jan"
             )
         )
 
@@ -31,7 +32,7 @@ def test_simple(tmp_library: TemporaryLibrary) -> None:
         data = yaml.load(fd, Loader=papis.yaml.Loader)  # type: ignore[attr-defined]
         expected_doc = papis.document.from_data(data)
 
-    assert expected_doc["authors"] == doc["authors"]
+    assert expected_doc["author"] == doc["author"]
 
     # FIXME: currently fails on windows
     # assert doc.get_files()

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -10,6 +10,7 @@ import papis_zotero.sql
 from .testlib import TemporaryLibrary
 
 
+@pytest.mark.skipif(os.name == "nt", reason="encoding is incorrect on windows")
 @pytest.mark.library_setup(populate=False)
 def test_simple(tmp_library: TemporaryLibrary) -> None:
     sqlpath = os.path.join(os.path.dirname(__file__), "resources", "sql")


### PR DESCRIPTION
As per discussion in papis/papis#765, this proposal imports papers from Zotero using the `papis.command.add.run` API instead of writing out yaml files. I took advantage to rename the arguments too and allow the use of the `link` argument.