### PR TITLE
feat(server): add snapshot handling

### DIFF
--- a/papis_zotero/server.py
+++ b/papis_zotero/server.py
@@ -217,7 +217,7 @@ class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
     def handle_post_snapshot(self) -> None:
         import tempfile
         import datetime
-        import urllib
+        import urllib.parse
 
         rawinput = self.read_input()
         data = json.loads(rawinput.decode("utf-8"))

--- a/papis_zotero/server.py
+++ b/papis_zotero/server.py
@@ -223,7 +223,10 @@ class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
         import urllib.parse
 
         rawinput = self.read_input()
-        data = json.loads(rawinput.decode("utf-8"))
+        try:
+            data = json.loads(rawinput.decode("utf-8"))
+        except json.JSONDecodeError as e:
+            logger.error("Failed to decode data from the Zotero connector.", exc_info=e)
 
         html_template = """
         <!DOCTYPE html>

--- a/papis_zotero/server.py
+++ b/papis_zotero/server.py
@@ -70,6 +70,9 @@ def zotero_data_to_papis_data(item: Dict[str, Any]) -> Dict[str, Any]:
     item.pop("uri", None)
     item.pop("sessionID", None)
 
+    if item["referrer"] == "":
+        item.pop("referrer", None)
+
     for foreign_key, key in papis_zotero.utils.ZOTERO_TO_PAPIS_FIELDS.items():
         if foreign_key in item:
             item[key] = item.pop(foreign_key)


### PR DESCRIPTION
This implements a prototype version to save snapshots from Zotero into the papis library.

I have tried it briefly and it works fine thanks to the great work done on the server. It was really easy to implement this preliminary version!

From my tests, I have created a snapshot of this pull request (the name of the action on the menu is called "web page with snapshot").

`papis zotero serve` was executed through the VS Code debugger.

Right now, I can get the metadata of the page:

```yaml
author: github.com
files:
- tmpfxhiuo0b.html
month: 3
papis_id: 3d134e52facca33caecad4a7ae014a9f
ref: github_com2024ComparingPapis_Main_Kiike_Pr_Server_Snapshots
sessionID: Bqa4xPcA
singleFile: true
skipSnapshot: false
title: Comparing papis:main...kiike:pr-server-snapshots · papis/papis-zotero
url: https://github.com/papis/papis-zotero/compare/main...kiike:pr-server-snapshots?expand=1
year: '2024'
```
and also the actual snapshot of the website that is seen:

- with internet connection: 
    ![image](https://github.com/papis/papis-zotero/assets/464625/e78c3aff-9890-4771-bb43-5e4abd29bc03)

- offline:
    ![image](https://github.com/papis/papis-zotero/assets/464625/92c80a21-54f3-4692-b311-ea5ddec52be5)

I think so far we have something functional that fulfills basic requirements.

Let me know what you think!