### PR TITLE
style: fix typos in __init__.py and utils.py

### DIFF
--- a/papis_zotero/__init__.py
+++ b/papis_zotero/__init__.py
@@ -73,7 +73,7 @@ def serve(address: str, port: int) -> None:
               default=None,
               type=str)
 @click.option("--link",
-              help="Wether to link the pdf files or copy them",
+              help="Whether to link the pdf files or copy them",
               is_flag=True,
               default=False)
 def do_importer(from_bibtex: Optional[str], from_sql: Optional[str],

--- a/papis_zotero/utils.py
+++ b/papis_zotero/utils.py
@@ -14,7 +14,7 @@ ZOTERO_EXCLUDED_FIELDS = frozenset({
     "accessDate",
     "id",
     "shortTitle",
-    "attachements",
+    "attachments",
 })
 
 # dictionary of Zotero attachments mimetypes to be included


### PR DESCRIPTION
I noticed a couple minor typos with codespell. I didn't know about this tool and learned about it from the papis repo, so thanks!