### PR TITLE
Add tag to imported document

### DIFF
--- a/papis_zotero/__init__.py
+++ b/papis_zotero/__init__.py
@@ -1,3 +1,4 @@
+from functools import partial
 import os
 import http.server
 from typing import Optional
@@ -24,7 +25,8 @@ def main() -> None:
               default=papis_zotero.server.ZOTERO_PORT,
               type=int)
 @click.option("--address", help="Address to bind", default="localhost")
-def serve(address: str, port: int) -> None:
+@click.option("-t", "--add-tag", help="Tag that is added to the document", default=None)
+def serve(address: str, port: int, add_tag: Optional[str]) -> None:
     """Start a ``zotero-connector`` server."""
 
     logger.warning("The 'zotero-connector' server is experimental. "
@@ -32,9 +34,9 @@ def serve(address: str, port: int) -> None:
                    "https://github.com/papis/papis-zotero/issues.")
 
     server_address = (address, port)
+    request_handler = partial(papis_zotero.server.PapisRequestHandler, add_tag)
     try:
-        httpd = http.server.HTTPServer(server_address,
-                                       papis_zotero.server.PapisRequestHandler)
+        httpd = http.server.HTTPServer(server_address, request_handler)
     except OSError:
         logger.error(
             "Address '%s:%s' is already in use. This may be because you "

--- a/papis_zotero/__init__.py
+++ b/papis_zotero/__init__.py
@@ -1,7 +1,7 @@
 from functools import partial
 import os
 import http.server
-from typing import Optional
+from typing import List, Optional, Tuple
 
 import click
 
@@ -25,8 +25,12 @@ def main() -> None:
               default=papis_zotero.server.ZOTERO_PORT,
               type=int)
 @click.option("--address", help="Address to bind", default="localhost")
-@click.option("-t", "--add-tag", help="Tag that is added to the document", default=None)
-def serve(address: str, port: int, add_tag: Optional[str]) -> None:
+@click.option(
+    "-s", "--set", "set_list",
+    help="Set imported document metadata as <key> <value>. Can be used multiple times.",
+    multiple=True,
+    type=(str, str))
+def serve(address: str, port: int, set_list: List[Tuple[str, str]],) -> None:
     """Start a ``zotero-connector`` server."""
 
     logger.warning("The 'zotero-connector' server is experimental. "
@@ -34,7 +38,7 @@ def serve(address: str, port: int, add_tag: Optional[str]) -> None:
                    "https://github.com/papis/papis-zotero/issues.")
 
     server_address = (address, port)
-    request_handler = partial(papis_zotero.server.PapisRequestHandler, add_tag)
+    request_handler = partial(papis_zotero.server.PapisRequestHandler, set_list)
     try:
         httpd = http.server.HTTPServer(server_address, request_handler)
     except OSError:

--- a/papis_zotero/server.py
+++ b/papis_zotero/server.py
@@ -70,7 +70,7 @@ def zotero_data_to_papis_data(item: Dict[str, Any]) -> Dict[str, Any]:
     item.pop("uri", None)
     item.pop("sessionID", None)
 
-    if item["referrer"] == "":
+    if item.get("referrer") == "":
         item.pop("referrer", None)
 
     for foreign_key, key in papis_zotero.utils.ZOTERO_TO_PAPIS_FIELDS.items():

--- a/papis_zotero/server.py
+++ b/papis_zotero/server.py
@@ -122,6 +122,11 @@ def download_zotero_attachments(attachments: List[Dict[str, str]]) -> List[str]:
 
 
 class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
+    def __init__(self, add_tag: str, request: Any,
+                 client_address: Any, server: Any) -> None:
+        self.add_tag: str = add_tag
+        super().__init__(request, client_address, server)
+
     def log_message(self, fmt: str, *args: Any) -> None:
         logger.info(fmt, *args)
 
@@ -209,6 +214,11 @@ class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
                 files = []
 
             papis_item = zotero_data_to_papis_data(item)
+            if papis_item.get("tags"):
+                papis_item["tags"].append(self.add_tag)
+            else:
+                papis_item["tags"] = [self.add_tag]
+
             logger.info("Adding paper to papis.")
             papis.commands.add.run(files, data=papis_item)
 

--- a/papis_zotero/server.py
+++ b/papis_zotero/server.py
@@ -7,7 +7,7 @@ into papis.
 
 import json
 import http.server
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple
 
 import papis.api
 import papis.crossref
@@ -122,9 +122,9 @@ def download_zotero_attachments(attachments: List[Dict[str, str]]) -> List[str]:
 
 
 class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
-    def __init__(self, add_tag: str, request: Any,
+    def __init__(self, set_list: List[Tuple[str, str]], request: Any,
                  client_address: Any, server: Any) -> None:
-        self.add_tag: str = add_tag
+        self.set_list = set_list
         super().__init__(request, client_address, server)
 
     def log_message(self, fmt: str, *args: Any) -> None:
@@ -214,10 +214,8 @@ class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
                 files = []
 
             papis_item = zotero_data_to_papis_data(item)
-            if papis_item.get("tags"):
-                papis_item["tags"].append(self.add_tag)
-            else:
-                papis_item["tags"] = [self.add_tag]
+            if self.set_list:
+                papis_item.update(self.set_list)
 
             logger.info("Adding paper to papis.")
             papis.commands.add.run(files, data=papis_item)


### PR DESCRIPTION
This is a small PR that adds a feature that I use in my workflow: when I come upon an item that is interesting, I'd like to add it to papis with an automatic tag. In my workflow it's "inbox" so that i can search for all "inbox"'ed documents, which are the ones I need to review.

To achieve this, just run `papis zotero serve -s tags inbox`. Of course, when no tag is provided, no tags or empty tag list will be added to the papis document.