### PR TITLE
fix(server): prevent exception when getting an empty referrer

### DIFF
--- a/papis_zotero/server.py
+++ b/papis_zotero/server.py
@@ -70,7 +70,7 @@ def zotero_data_to_papis_data(item: Dict[str, Any]) -> Dict[str, Any]:
     item.pop("uri", None)
     item.pop("sessionID", None)
 
-    if item["referrer"] == "":
+    if item.get("referrer") == "":
         item.pop("referrer", None)
 
     for foreign_key, key in papis_zotero.utils.ZOTERO_TO_PAPIS_FIELDS.items():


### PR DESCRIPTION
I encountered a stupid bug that I encountered after a long while using the server. Apparently `referrer` can be undefined, so we'll make a check before removing it if empty.