### PR TITLE
feat: add Nix flake

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,39 @@ To install the latest development version
 
 .. code:: bash
 
-   python -m pip install papis-zotero@https://github.com/papis/papis-zotero.git#egg=papis-zotero
+    python -m pip install papis-zotero@https://github.com/papis/papis-zotero.git#egg=papis-zotero
+
+For Nix or NixOS users, a ``flake.nix`` is available for use.  It currently
+provides a ``devShell`` configuration for use with ``nix develop``, as well as
+packages for `nix shell` or for installation. While the `devShell` is ready to
+use when you activate a develop shell, for installation you might want to do
+something like
+
+.. code:: nix
+{
+  pkgs,
+  inputs,
+  ...
+}: {
+  home.packages = with pkgs; [
+    (
+      python3.withPackages
+      (
+        ps: [
+          inputs.papis.packages.${system}.default
+          inputs.papis-zotero.packages.${system}.default
+          # you can add other packages you might want to make available for papis
+          # ps.jinja2
+        ]
+      )
+    )
+    # Here you can list other packages, such as
+    # typst
+    # hayagriva
+    # zotero_7
+  ];
+}
+
 
 Development
 -----------

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,258 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "mdbook-nixdoc": {
+      "inputs": {
+        "nix-github-actions": [
+          "papis",
+          "pyproject-nix",
+          "nix-github-actions"
+        ],
+        "nixpkgs": [
+          "papis",
+          "pyproject-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1708395692,
+        "narHash": "sha256-smf0VmxGbjJDZqKvxxG3ZVqubgbVwAWG26wPo+BT/A0=",
+        "owner": "adisbladis",
+        "repo": "mdbook-nixdoc",
+        "rev": "d6a71b114b9221c0b4f20d31b81766d072cc26be",
+        "type": "github"
+      },
+      "original": {
+        "owner": "adisbladis",
+        "repo": "mdbook-nixdoc",
+        "type": "github"
+      }
+    },
+    "mdbook-nixdoc_2": {
+      "inputs": {
+        "nix-github-actions": [
+          "pyproject-nix",
+          "nix-github-actions"
+        ],
+        "nixpkgs": [
+          "pyproject-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1708395692,
+        "narHash": "sha256-smf0VmxGbjJDZqKvxxG3ZVqubgbVwAWG26wPo+BT/A0=",
+        "owner": "adisbladis",
+        "repo": "mdbook-nixdoc",
+        "rev": "d6a71b114b9221c0b4f20d31b81766d072cc26be",
+        "type": "github"
+      },
+      "original": {
+        "owner": "adisbladis",
+        "repo": "mdbook-nixdoc",
+        "type": "github"
+      }
+    },
+    "nix-github-actions": {
+      "inputs": {
+        "nixpkgs": [
+          "papis",
+          "pyproject-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1703863825,
+        "narHash": "sha256-rXwqjtwiGKJheXB43ybM8NwWB8rO2dSRrEqes0S7F5Y=",
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "rev": "5163432afc817cf8bd1f031418d1869e4c9d5547",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "type": "github"
+      }
+    },
+    "nix-github-actions_2": {
+      "inputs": {
+        "nixpkgs": [
+          "pyproject-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1703863825,
+        "narHash": "sha256-rXwqjtwiGKJheXB43ybM8NwWB8rO2dSRrEqes0S7F5Y=",
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "rev": "5163432afc817cf8bd1f031418d1869e4c9d5547",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1713248628,
+        "narHash": "sha256-NLznXB5AOnniUtZsyy/aPWOk8ussTuePp2acb9U+ISA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "5672bc9dbf9d88246ddab5ac454e82318d094bb8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "papis": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "pyproject-nix": "pyproject-nix"
+      },
+      "locked": {
+        "lastModified": 1713273708,
+        "narHash": "sha256-3A6IqB7/gF09hEdKDzO4The0q0LK1+VJ2yvnRwof3Co=",
+        "owner": "papis",
+        "repo": "papis",
+        "rev": "4bd6ca5d6011eb612b54efa19f10d13956a380b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "papis",
+        "repo": "papis",
+        "type": "github"
+      }
+    },
+    "pyproject-nix": {
+      "inputs": {
+        "mdbook-nixdoc": "mdbook-nixdoc",
+        "nix-github-actions": "nix-github-actions",
+        "nixpkgs": [
+          "papis",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709886419,
+        "narHash": "sha256-qXZsmegy0W0hn9yxYQFin1jZB3ikmBWXyBDQx1AqEQ4=",
+        "owner": "nix-community",
+        "repo": "pyproject.nix",
+        "rev": "2841577401c77106150b98bcb3a30510cb6c652a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
+    "pyproject-nix_2": {
+      "inputs": {
+        "mdbook-nixdoc": "mdbook-nixdoc_2",
+        "nix-github-actions": "nix-github-actions_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1712595520,
+        "narHash": "sha256-6F1KAT+iXukGaoBJ0uiAVlPL8VsgKvwtyt/3WASMwiI=",
+        "owner": "nix-community",
+        "repo": "pyproject.nix",
+        "rev": "794220b75a5cddd88f2a6ac6e557a01bc3a9806c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "papis": "papis",
+        "pyproject-nix": "pyproject-nix_2"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,138 @@
+{
+  description = "Zotero compatibility layer for Papis";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    papis = {
+      url = "github:papis/papis";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    pyproject-nix = {
+      url = "github:nix-community/pyproject.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    pyproject-nix,
+    papis,
+  }:
+    flake-utils.lib.eachDefaultSystem (
+      system: let
+        pypkgs = pkgs.python3Packages;
+        pkgs = nixpkgs.legacyPackages.${system};
+        python = pkgs.python3.override {
+          packageOverrides = self: super: {
+            papis = papis.packages.${system}.default;
+            flake8-quotes = flake8-quotes;
+            flake8-pyproject = flake8-pyproject;
+            python-coveralls = python-coveralls;
+          };
+        };
+        project = pyproject-nix.lib.project.loadPyproject {projectRoot = ./.;};
+
+        flake8-quotes = python.pkgs.buildPythonPackage rec {
+          pname = "flake8-quotes";
+          version = "3.4.0";
+
+          src = python.pkgs.fetchPypi {
+            inherit pname version;
+            sha256 = "sha256-qthJL7cQotPqvmjF+GoUKN5lDISEEn4UxD0FBLowJ2w=";
+          };
+
+          doCheck = false;
+          checkInputs = [];
+
+          meta = with pkgs.lib; {
+            homepage = "http://github.com/zheller/flake8-quotes";
+            description = "Flake8 lint for quotes.";
+            license = licenses.mit;
+          };
+        };
+
+        flake8-pyproject = python.pkgs.buildPythonPackage {
+          pname = "flake8-pyproject";
+          version = "1.2.3";
+          pyproject = true;
+
+          src = pkgs.fetchFromGitHub {
+            owner = "john-hen";
+            repo = "Flake8-pyproject";
+            rev = "30b8444781d16edd54c11df08210a7c8fb79258d";
+            hash = "sha256-bPRIj7tYmm6I9eo1ZjiibmpVmGcHctZSuTvnKX+raPg=";
+          };
+
+          doCheck = false;
+          checkInputs = [];
+          propagatedBuildInputs = [pypkgs.flit-core pypkgs.flake8];
+
+          meta = with pkgs.lib; {
+            homepage = "https://github.com/john-hen/Flake8-pyproject";
+            description = "Flake8 plug-in loading the configuration from pyproject.toml";
+            license = licenses.mit;
+          };
+        };
+
+        python-coveralls = python.pkgs.buildPythonPackage rec {
+          pname = "python-coveralls";
+          version = "2.9.3";
+
+          src = python.pkgs.fetchPypi {
+            inherit pname version;
+            sha256 = "sha256-v694EefcVijoO2sWKWKk4khdv/GEsw5J84A3TtG87lU=";
+          };
+
+          doCheck = false;
+          checkInputs = [];
+
+          meta = with pkgs.lib; {
+            homepage = "http://github.com/z4r/python-coveralls";
+            description = "Python interface to coveralls.io API ";
+            license = licenses.asl20;
+          };
+        };
+      in {
+        packages = {
+          papis-zotero = let
+            attrs = project.renderers.buildPythonPackage {
+              inherit python;
+            };
+          in
+            python.pkgs.buildPythonPackage (attrs
+              // {
+                version =
+                  if (self ? rev)
+                  then self.shortRev
+                  else self.dirtyShortRev;
+                propagatedBuildInputs = [
+                  papis.packages.${system}.default
+                ];
+              });
+          default = self.packages.${system}.papis-zotero;
+        };
+
+        devShells = {
+          default = let
+            arg = project.renderers.withPackages {
+              inherit python;
+              extras = ["develop"];
+            };
+            pythonEnv = python.withPackages arg;
+          in
+            pkgs.mkShell {
+              packages = [
+                pythonEnv
+                self.packages.${system}.papis-zotero
+              ];
+              shellHook = ''
+                export PYTHONPATH="$(pwd):$PYTHONPATH"
+              '';
+            };
+        };
+      }
+    );
+}


### PR DESCRIPTION
This PR adds a flake for Nix users. I have been using it on NixOS for a couple days when developing. It lets me avoid having a virtualenv, or even having the dev tools installed globally. Feature-wise, it's on par with the Papis one, except for the container stuff, which is not implemented yet. It might be a nice-to-have in the future though!