### PR TITLE
Add PyPI release job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,3 +40,29 @@ jobs:
     - name: Test with pytest
       run: |
         make pytest
+
+  pypi-release:
+    needs: [build]
+    name: PyPI Release
+    environment: pypi
+    permissions:
+      contents: write
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - id: dist
+      run: |
+        make ci-install-build-system
+        python -m build .
+
+    - if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+      name: Publish Package to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,10 @@ pytest:								## Run pytest test and doctests
 	python -m pytest -rswx -v -s tests
 .PHONY: pytest
 
-ci-install:							## Run pip and install dependencies on CI
-	python -m pip install --upgrade pip hatchling wheel
+ci-install-build-system:
+	python -m pip install --upgrade pip hatchling wheel build
+.PHONY: ci-install-build-system
+
+ci-install: ci-install-build-system	## Run pip and install dependencies on CI
 	python -m pip install -e '.[develop]'
 .PHONY: ci-install


### PR DESCRIPTION
This adds a PyPI release job to the CI similar to how Papis is doing it. Should allow for easier releases once everything is set up.

@alejandrogallo Could we add Github as a Trusted Publisher for `papis-zotero` as well? We can then make a new release for this compatible with Papis 0.14 :grin:

Fixes #55 