### PR TITLE
Run CI on tag pushes to enable publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,10 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches: [ "main" ]
+    tags: [ 'v**' ]
   pull_request:
     branches: [ "main" ]
   schedule:


### PR DESCRIPTION
@alejandrogallo Actually, this might also be an issue.. forgot to enable to the workflow on tag pushes :\