### PR TITLE
Fix crash when zotero attachment path is missing from sqlite

### DIFF
--- a/papis_zotero/sql.py
+++ b/papis_zotero/sql.py
@@ -135,7 +135,7 @@ def get_files(connection: sqlite3.Connection, item_id: str, item_key: str,
     for key, path, mime_type in cursor:
         if path is None:
             logger.warning("Attachment %s (with type %s) skipped. Path not specified.",
-                          key, mime_type)
+                           key, mime_type)
             continue
 
         if match := re.match("storage:(.*)", path):


### PR DESCRIPTION
I ran into a `TypeError` with `re.match` when the `path` from sqlite was `None`. Before my change, this would crash the Zotero import process. This fix checks for that condition and prints a warning message. I've verified that I can successfully import my Zotero library with the updated code.