### PR TITLE
Bump version to match new Papis release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "hatchling>=1.10" ]
 
 [project]
 name = "papis-zotero"
-version = "0.2"
+version = "0.3.0"
 description = "Interact with Zotero using papis"
 readme = "README.rst"
 keywords = [ "bibtex", "biliography", "cli", "management", "papis", "zotero" ]
@@ -33,7 +33,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
     "Topic :: Utilities",
 ]
-dependencies = [ "papis>=0.14,<0.15" ]
+dependencies = [ "papis>=0.15,<0.16" ]
 
 [project.optional-dependencies]
 develop = [


### PR DESCRIPTION
cc @alejandrogallo Will go ahead and make a new release for `papis-zotero` too when this passes to match papis 0.15.0