### PR TITLE
Use getformatpattern for add-folder-name

### DIFF
--- a/papis_zotero/bibtex.py
+++ b/papis_zotero/bibtex.py
@@ -14,15 +14,17 @@ RE_SEPARATOR = re.compile(r"\s*,\s*")
 def add_from_bibtex(bib_file: str,
                     out_folder: str | None = None,
                     link: bool = False) -> None:
-    from papis.config import set_lib_from_name
+    from papis.config import getformatpattern, set_lib_from_name
 
     if out_folder is not None:
         set_lib_from_name(out_folder)
+    folder_name = getformatpattern("add-folder-name")
 
     from papis.bibtex import bibtex_to_dict, create_reference, ref_cleanup
 
     entries = bibtex_to_dict(bib_file)
     nentries = len(entries)
+
     for i, entry in enumerate(entries):
         result: dict[str, Any] = entry.copy()
 
@@ -60,4 +62,5 @@ def add_from_bibtex(bib_file: str,
                     i, nentries, result["ref"])
 
         from papis.commands.add import run as add
-        add([pdf_file] if pdf_file is not None else [], data=result, link=link)
+        add([pdf_file] if pdf_file is not None else [], data=result, link=link,
+            folder_name=folder_name)

--- a/papis_zotero/server.py
+++ b/papis_zotero/server.py
@@ -276,8 +276,9 @@ class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
         logger.info("Adding snapshot to Papis.")
 
         from papis.commands.add import run as add
-        from papis.config import getstring
-        add([temp_html], data=papis_item, folder_name=getstring("add-folder-name"))
+        from papis.config import getformatpattern
+        add([temp_html], data=papis_item,
+            folder_name=getformatpattern("add-folder-name"))
 
         self.send_response(201)
         self.set_zotero_headers()

--- a/papis_zotero/sql.py
+++ b/papis_zotero/sql.py
@@ -235,7 +235,7 @@ def add_from_sql(input_path: str,
     :param outpath: path where all items will be exported to created if not
         existing
     """
-    from papis.config import get_lib_dirs, getstring, set_lib_from_name
+    from papis.config import get_lib_dirs, getformatpattern, set_lib_from_name
 
     if out_folder is None:
         out_folder = get_lib_dirs()[0]
@@ -266,7 +266,7 @@ def add_from_sql(input_path: str,
 
     from papis.strings import time_format
 
-    folder_name = getstring("add-folder-name")
+    folder_name = getformatpattern("add-folder-name")
     for i, (item_id, zitem_type, item_key, zdate_added) in enumerate(cursor, start=1):
         # convert fields
         date_added = (
@@ -292,7 +292,8 @@ def add_from_sql(input_path: str,
                     i, items_count, item_key, out_folder)
 
         from papis.commands.add import run as add
-        add(paths=files, data=item, link=link, folder_name=folder_name)
+        add(files, data=item, link=link,
+            folder_name=folder_name)
 
     logger.info("Finished exporting from '%s'.", input_path)
     logger.info("Exported files can be found at '%s'.", out_folder)


### PR DESCRIPTION
`add-folder-name` became a format pattern in the latest Papis, so retrieving it with `getstring` was failing.