### PR TITLE
Correctly set lib name so that it picks up settings

### DIFF
--- a/papis_zotero/bibtex.py
+++ b/papis_zotero/bibtex.py
@@ -6,6 +6,8 @@ from typing import Any
 
 import papis.logging
 
+from papis_zotero.utils import set_lib_from_path
+
 logger = papis.logging.get_logger(__name__)
 
 RE_SEPARATOR = re.compile(r"\s*,\s*")
@@ -14,10 +16,10 @@ RE_SEPARATOR = re.compile(r"\s*,\s*")
 def add_from_bibtex(bib_file: str,
                     out_folder: str | None = None,
                     link: bool = False) -> None:
-    from papis.config import getformatpattern, set_lib_from_name
+    from papis.config import getformatpattern
 
     if out_folder is not None:
-        set_lib_from_name(out_folder)
+        set_lib_from_path(out_folder)
     folder_name = getformatpattern("add-folder-name")
 
     from papis.bibtex import bibtex_to_dict, create_reference, ref_cleanup

--- a/papis_zotero/sql.py
+++ b/papis_zotero/sql.py
@@ -14,6 +14,7 @@ from papis_zotero.utils import (
     ZOTERO_SUPPORTED_MIMETYPES_TO_EXTENSION,
     ZOTERO_TO_PAPIS_FIELDS,
     ZOTERO_TO_PAPIS_TYPES,
+    set_lib_from_path,
 )
 
 logger = papis.logging.get_logger(__name__)
@@ -235,7 +236,7 @@ def add_from_sql(input_path: str,
     :param outpath: path where all items will be exported to created if not
         existing
     """
-    from papis.config import get_lib_dirs, getformatpattern, set_lib_from_name
+    from papis.config import get_lib_dirs, getformatpattern
 
     if out_folder is None:
         out_folder = get_lib_dirs()[0]
@@ -262,7 +263,7 @@ def add_from_sql(input_path: str,
 
     cursor.execute(ZOTERO_QUERY_ITEMS, ZOTERO_EXCLUDED_ITEM_TYPES)
     if out_folder is not None:
-        set_lib_from_name(out_folder)
+        set_lib_from_path(out_folder)
 
     from papis.strings import time_format
 

--- a/papis_zotero/utils.py
+++ b/papis_zotero/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import tempfile
 from typing import Any
 
@@ -139,3 +140,20 @@ def download_document(
         f.write(response.content)
 
     return f.name
+
+
+def set_lib_from_path(libname_or_path: str) -> None:
+    from papis.config import get_lib_from_name, get_libs, set_lib_from_name
+
+    if os.path.exists(libname_or_path):
+        libname_or_path = os.path.abspath(os.path.expanduser(libname_or_path))
+
+    orig_libname = None
+    libs = get_libs()
+    for libname in libs:
+        lib = get_lib_from_name(libname)
+        if libname_or_path in lib.paths:
+            orig_libname = lib.name
+            break
+
+    set_lib_from_name(orig_libname if orig_libname else libname_or_path)


### PR DESCRIPTION
We were using `set_lib_from_name(folder)`, which would always construct a new library just for that folder. In particular, that would keep Papis from correctly identifying settings if the folder belonged to an existing library. 

We now try to match the folder to an existing library first. This is a bit hacky, but it seems to work.