### PR TITLE
better file search in zotero imprt

### DIFF
--- a/papis_zotero/bibtex.py
+++ b/papis_zotero/bibtex.py
@@ -47,22 +47,29 @@ def add_from_bibtex(bib_file: str,
             result["ref"] = create_reference(result)
 
         # get file
-        pdf_file = result.pop("file", None)
-        if pdf_file is not None:
-            pdf_file = pdf_file.split(":")[1]
-            pdf_file = os.path.join(*pdf_file.split("/"))
-            pdf_file = os.path.join(os.path.dirname(bib_file), pdf_file)
+        file_field = result.pop("file", None)
+        if file_field is not None:
 
-            if os.path.exists(pdf_file):
-                logger.info("Document file found: '%s'.", pdf_file)
-            else:
-                logger.warning("Document file not found: '%s'.", pdf_file)
-                pdf_file = None
+            # captures path ending in ".extension", followed by :, ; or }
+            pattern = r"(?:/home|\./|(?<=:)).+?\.\w+(?=[:;}])"
 
-        # add to library
-        logger.info("[%4d/%-4d] Exporting item with ref '%s'.",
-                    i, nentries, result["ref"])
+            paths = re.findall(pattern, file_field)
 
-        from papis.commands.add import run as add
-        add([pdf_file] if pdf_file is not None else [], data=result, link=link,
-            folder_name=folder_name)
+            from papis.commands.add import run as add
+            for p in paths:
+
+                if not p.startswith("/home"):
+                    path = os.path.join(os.path.dirname(bib_file), p)
+                else:
+                    path = p
+
+                if os.path.exists(path):
+                    logger.info("Document file found: '%s'.", path)
+
+                    logger.info("[%4d/%-4d] Exporting item with ref '%s'.",
+                            i, nentries, result["ref"])
+
+                    add([path], data=result, link=link, folder_name=folder_name)
+
+                else:
+                    logger.warning("Document file not found: '%s'.", path)

--- a/papis_zotero/bibtex.py
+++ b/papis_zotero/bibtex.py
@@ -47,29 +47,32 @@ def add_from_bibtex(bib_file: str,
             result["ref"] = create_reference(result)
 
         # get file
-        file_field = result.pop("file", None)
-        if file_field is not None:
+        file_field = result.pop("file", "")
 
-            # captures path ending in ".extension", followed by :, ; or }
-            pattern = r"(?:/home|\./|(?<=:)).+?\.\w+(?=[:;}])"
+        path_list = []
 
-            paths = re.findall(pattern, file_field)
+        # captures path ending in ".extension", followed by :, ; or }
+        pattern = r"(?:/home|\./|(?<=:)).+?\.\w+(?=[:;}])"
+        captured_paths = re.findall(pattern, file_field)
 
-            from papis.commands.add import run as add
-            for p in paths:
+        for p in captured_paths:
 
-                if not p.startswith("/home"):
-                    path = os.path.join(os.path.dirname(bib_file), p)
-                else:
-                    path = p
+            path = (p if os.path.isabs(p)
+                    else os.path.join(os.path.dirname(bib_file), p))
 
-                if os.path.exists(path):
-                    logger.info("Document file found: '%s'.", path)
+            if os.path.exists(path):
+                logger.info("Document file found: '%s'.", path)
+                path_list.append(path)
+            else:
+                logger.warning(
+                    "Attachment found but path does not exist: '%s'.", path)
 
-                    logger.info("[%4d/%-4d] Exporting item with ref '%s'.",
-                            i, nentries, result["ref"])
+        if len(path_list) == 0:
+            logger.warning("Document files not found: '%s'.")
 
-                    add([path], data=result, link=link, folder_name=folder_name)
-
-                else:
-                    logger.warning("Document file not found: '%s'.", path)
+        from papis.commands.add import run as add
+        logger.info(
+            "[%4d/%-4d] Exporting item with ref '%s'.",
+            i, nentries, result["ref"]
+        )
+        add(path_list, data=result, link=link, folder_name=folder_name)

--- a/tests/resources/bibtex/zotero-library.bib
+++ b/tests/resources/bibtex/zotero-library.bib
@@ -12,7 +12,7 @@
 	author = {Schaeffer, Nathanaël},
 	urldate = {2023-02-26},
 	date = {2013-03},
-	langid = {english}
+	langid = {english},
 	file = {Full Text:files/8/Schaeffer - 2013 - Efficient spherical harmonic transforms aimed at p.pdf:application/pdf},
 }
 


### PR DESCRIPTION
This commit changes the way file paths are identified.

Addresses one of the problems in #74 .

It covers biblatex zotero exports:
```
file = {David J. Griffiths - Instructor’s Solution Manuals to Introduction to Electrodynamics-Pearson (2012):/home/username/Zotero/storage/7QDCEZT6/David J. Griffiths - Instructor’s Solution Manuals to Introduction to Electrodynamics-Pearson (2012).pdf:application/pdf;PDF:/home/username/Zotero/storage/6UHUGG6B/Griffiths - 2013 - Introduction to electrodynamics.pdf:application/pdf},
```

as well as `better biblatex`:
```
file = {/home/username/Zotero/storage/6UHUGG6B/Griffiths - 2013 - Introduction to electrodynamics.pdf;/home/username/Zotero/storage/7QDCEZT6/David J. Griffiths - Instructor’s Solution Manuals to Introduction to Electrodynamics-Pearson (2012).pdf},
```
, as well as the examples in the tests.


Hopefully works for multiple files of any file extension, not just pdf's.